### PR TITLE
feat: Add custom format option to ConsoleHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ format function in a second `options argument`.
 
 ```typescript
 const myFormat = (record: ILogRecord) =>
-  `${record.context} - ${record.message}`; // Return you custom format as a string.
+  `${record.levelName} - ${record.message}`; // Return you custom format as a string.
 
 const logger = new Logger().addHandler(
   new ConsoleHandler(LogLevel.INFO, { format: myFormat })
 );
 
 logger.info("With custom format.");
-// Default - With custom format.
+// INFO - With custom format.
 ```
 
 ## Create a custom handler:

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ interface IConsoleHandlerOptions {
 ```
 
 You can change the output format by providing a `format` function as an `option`.
-Default output format is: `ISO-time-string [context] message`.
+Default output format is: `level: [context] - message`.
 
 The `ConsoleHandler` classed has a static `toggle` method with might be used in
 a browser to toggle of all logs in production but toggle them back on with a

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Requires a min. LogLevel when initialized. Everything below this level will not
 be logged. Accepts an optional `options object` as a second argument.
 
 ```typescript
-interface ConsoleHandlerOptions {
+interface IConsoleHandlerOptions {
   format?: (record: ILogRecord) => string;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,10 +32,17 @@
 
 ## Upcoming features
 
-1. Format function for handlers to custom format the logs.
 1. Exported default logger which can be overwritten.
 1. More handlers directly provided.
 1. Your idea? Let me know!
+
+## Installation
+
+```bash
+npm i logging-library
+# or
+yarn add logging-library
+```
 
 ## Usage
 
@@ -95,6 +102,23 @@ const scoped = logger.withContext("Authentication");
 
 // Nobody stops you from storing the scoped logger if needed...
 LoggerStore.add("auth", scoped);
+```
+
+## Provide a custom format:
+
+You can change the output format of the `ConsoleHandler` by providing a custom
+format function in a second `options argument`.
+
+```typescript
+const myFormat = (record: ILogRecord) =>
+  `${record.context} - ${record.message}`; // Return you custom format as a string.
+
+const logger = new Logger().addHandler(
+  new ConsoleHandler(LogLevel.INFO, { format: myFormat })
+);
+
+logger.info("With custom format.");
+// Default - With custom format.
 ```
 
 ## Create a custom handler:
@@ -178,8 +202,8 @@ interface ILogger {
 
 ### `LoggerStore`
 
-Little helper class that uses a static map to store loggers globally. Using the
-same key twice, overrides a logger.
+> Little helper class that uses a static map to store loggers globally. Using
+> the same key twice, overrides a logger.
 
 ```typescript
 class LoggerStore {
@@ -191,9 +215,19 @@ class LoggerStore {
 
 ### ConsoleHandler
 
-Logs records the the corresponding method on the `console` object.
+> Logs records the the corresponding method on the `console` object.
 
-Output format: `ISO-time-string [context] message`
+Requires a min. LogLevel when initialized. Everything below this level will not
+be logged. Accepts an optional `options object` as a second argument.
+
+```typescript
+interface ConsoleHandlerOptions {
+  format?: (record: ILogRecord) => string;
+}
+```
+
+You can change the output format by providing a `format` function as an `option`.
+Default output format is: `ISO-time-string [context] message`.
 
 The `ConsoleHandler` classed has a static `toggle` method with might be used in
 a browser to toggle of all logs in production but toggle them back on with a
@@ -209,8 +243,8 @@ globalThis.toggleConsoleLogging = ConsoleHandler.toggle;
 
 ### TestHandler
 
-Handler that writes all logs into a message queue which. Allows for assertions
-about logs during testing.
+> Handler that writes all logs into a message queue which. Allows for assertions
+> about logs during testing.
 
 ```typescript
 class TestHandler extends BaseHandler {

--- a/src/handlers/console-handler.test.ts
+++ b/src/handlers/console-handler.test.ts
@@ -38,7 +38,7 @@ describe("ConsoleHandler", () => {
       handler.handle(record);
 
       expect(mock).toHaveBeenCalledWith(
-        `${record.date.toISOString()}\t[${record.context}]\t${record.message}`
+        `${record.levelName}: [${record.context}] - ${record.message}`
       );
 
       mock.mockRestore();

--- a/src/handlers/console-handler.ts
+++ b/src/handlers/console-handler.ts
@@ -2,7 +2,7 @@ import { BaseHandler } from "../handler";
 import { ILogRecord } from "../log-record";
 import { LogLevel } from "../log-level";
 
-interface ConsoleHandlerOptions {
+interface IConsoleHandlerOptions {
   format?: (record: ILogRecord) => string;
 }
 
@@ -15,7 +15,7 @@ export class ConsoleHandler extends BaseHandler {
 
   private readonly format: (record: ILogRecord) => string;
 
-  constructor(level: LogLevel, options?: ConsoleHandlerOptions) {
+  constructor(level: LogLevel, options?: IConsoleHandlerOptions) {
     super(level);
     this.format = options?.format ?? this.defaultFormat;
   }

--- a/src/handlers/console-handler.ts
+++ b/src/handlers/console-handler.ts
@@ -2,12 +2,23 @@ import { BaseHandler } from "../handler";
 import { ILogRecord } from "../log-record";
 import { LogLevel } from "../log-level";
 
+interface ConsoleHandlerOptions {
+  format?: (record: ILogRecord) => string;
+}
+
 /**
  * Writes logs to the console with the native `console` object. Log format:
  * ISO-time-string [context] message
  */
 export class ConsoleHandler extends BaseHandler {
   private static active = true;
+
+  private readonly format: (record: ILogRecord) => string;
+
+  constructor(level: LogLevel, options?: ConsoleHandlerOptions) {
+    super(level);
+    this.format = options?.format ?? this.defaultFormat;
+  }
 
   static toggle(active?: boolean): void {
     ConsoleHandler.active = active ?? !ConsoleHandler.active;
@@ -38,7 +49,7 @@ export class ConsoleHandler extends BaseHandler {
     }
   }
 
-  private format(record: ILogRecord): string {
+  private defaultFormat(record: ILogRecord): string {
     const timestring = record.date.toISOString();
 
     return `${timestring}\t[${record.context}]\t${record.msg}`;

--- a/src/handlers/console-handler.ts
+++ b/src/handlers/console-handler.ts
@@ -50,8 +50,6 @@ export class ConsoleHandler extends BaseHandler {
   }
 
   private defaultFormat(record: ILogRecord): string {
-    const timestring = record.date.toISOString();
-
-    return `${timestring}\t[${record.context}]\t${record.message}`;
+    return `${record.levelName}: [${record.context}] - ${record.message}`;
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,9 +10,6 @@ import {
 } from "./";
 
 test("Core logging functionality works as expected", () => {
-  const date = new Date("2020-04-01T12:15:32.000Z");
-  jest.useFakeTimers("modern");
-  jest.setSystemTime(date);
   const mockInfo = jest.spyOn(global.console, "info").mockImplementation();
   const mockWarn = jest.spyOn(global.console, "warn").mockImplementation();
   const mockDebug = jest.spyOn(global.console, "debug").mockImplementation();
@@ -28,10 +25,10 @@ test("Core logging functionality works as expected", () => {
   scoped.debug("Some debug information");
 
   expect(mockInfo).toHaveBeenCalledWith(
-    `${date.toISOString()}\t[Default]\tSome log using the default context.`
+    `INFO: [Default] - Some log using the default context.`
   );
   expect(mockWarn).toHaveBeenCalledWith(
-    `${date.toISOString()}\t[Authentication]\tThis log is using the 'Authentication' context`
+    `WARNING: [Authentication] - This log is using the 'Authentication' context`
   );
   expect(mockDebug).not.toHaveBeenCalled();
 


### PR DESCRIPTION
This adds an optional option argument to the `ConsoleHandler`. 

```typescript
interface IConsoleHandlerOptions {
  format?: (record: ILogRecord) => string;
}
```

This provides the ability to format the console output.

```typescript
const myFormat = (record: ILogRecord) =>
  `${record.context} - ${record.message}`; // Return you custom format as a string.

const logger = new Logger().addHandler(
  new ConsoleHandler(LogLevel.INFO, { format: myFormat })
);

logger.info("With custom format.");
// Default - With custom format.
```