### PR TITLE
feat: Handlers can log only for specific levels

### DIFF
--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -1,0 +1,83 @@
+import { BaseHandler } from "./handler";
+import { LogLevel } from "./log-level";
+import { buildLogRecord } from "./test-helper/log-record-builder";
+
+const logMock = jest.fn();
+class SpyHandler extends BaseHandler {
+  // Little SpyHandler to test BaseHandler since BaseHandler is abstract.
+  // We want to test BaseHandler as it implements crucial logic that
+  // user handler might rely on.
+  log = logMock;
+}
+
+describe("BaseHandler", () => {
+  it("should accept a level as a constructor argument", () => {
+    const handler = new SpyHandler(LogLevel.INFO);
+
+    expect(handler.level).toBe(LogLevel.INFO);
+  });
+
+  it("should accept an level array as a constructor argument", () => {
+    const handler = new SpyHandler([LogLevel.INFO, LogLevel.CRITICAL]);
+
+    expect(handler.level).toEqual([LogLevel.INFO, LogLevel.CRITICAL]);
+  });
+
+  describe("handle", () => {
+    it("should delegate logging to a subclass if the record level is equal to the given level", () => {
+      const handler = new SpyHandler(LogLevel.INFO);
+      const record = buildLogRecord({ level: LogLevel.INFO });
+
+      handler.handle(record);
+
+      expect(logMock).toHaveBeenCalledTimes(1);
+      expect(logMock).toHaveBeenCalledWith(record);
+    });
+
+    it("should delegate logging to a subclass if the record level is greater than the given level", () => {
+      const handler = new SpyHandler(LogLevel.INFO);
+      const record = buildLogRecord({ level: LogLevel.ERROR });
+      const record2 = buildLogRecord({ level: LogLevel.WARNING });
+
+      handler.handle(record);
+      handler.handle(record2);
+
+      expect(logMock).toHaveBeenCalledTimes(2);
+      expect(logMock).toHaveBeenCalledWith(record);
+      expect(logMock).toHaveBeenCalledWith(record2);
+    });
+
+    it("should not not delegate logging to a subclass if the record level is less than the given level", () => {
+      const handler = new SpyHandler(LogLevel.ERROR);
+      const record = buildLogRecord({ level: LogLevel.INFO });
+      const record2 = buildLogRecord({ level: LogLevel.WARNING });
+
+      handler.handle(record);
+      handler.handle(record2);
+
+      expect(logMock).toHaveBeenCalledTimes(0);
+    });
+
+    it("should delegate logging to a subclass if the record level is included in the given array", () => {
+      const handler = new SpyHandler([LogLevel.INFO, LogLevel.CRITICAL]);
+      const record = buildLogRecord({ level: LogLevel.INFO });
+      const record2 = buildLogRecord({ level: LogLevel.CRITICAL });
+
+      handler.handle(record);
+      handler.handle(record2);
+
+      expect(logMock).toHaveBeenCalledTimes(2);
+      expect(logMock).toHaveBeenCalledWith(record);
+      expect(logMock).toHaveBeenCalledWith(record2);
+    });
+
+    it("should not delegate logging to a subclass if the record level is not included in the given array", () => {
+      const handler = new SpyHandler([LogLevel.INFO, LogLevel.CRITICAL]);
+      const record = buildLogRecord({ level: LogLevel.WARNING });
+
+      handler.handle(record);
+
+      expect(logMock).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -5,7 +5,7 @@ import { buildLogRecord } from "./test-helper/log-record-builder";
 const logMock = jest.fn();
 class SpyHandler extends BaseHandler {
   // Little SpyHandler to test BaseHandler since BaseHandler is abstract.
-  // We want to test BaseHandler as it implements crucial logic that
+  // We want to test BaseHandler as it implements crucial logic that a
   // user handler might rely on.
   log = logMock;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -6,8 +6,8 @@ import { LogLevel } from "./log-level";
  * Alternatively custom handlers can extend the abstract class `BaseHandler`.
  */
 export interface ILogHandler {
-  readonly level: LogLevel;
-  handle(record: ILogRecord): void;
+  readonly level: LogLevel | LogLevel[];
+  handle(record: ILogRecord | LogLevel[]): void;
 }
 
 /**
@@ -17,13 +17,14 @@ export interface ILogHandler {
  * implementation.
  */
 export abstract class BaseHandler implements ILogHandler {
-  readonly level: LogLevel;
+  readonly level: LogLevel | LogLevel[];
 
-  constructor(level: LogLevel) {
+  constructor(level: LogLevel | LogLevel[]) {
     this.level = level;
   }
 
   handle(record: ILogRecord): void {
+    if (Array.isArray(this.level) && !this.level.includes(record.level)) return;
     if (this.level > record.level) return;
 
     this.log(record);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -7,7 +7,7 @@ import { LogLevel } from "./log-level";
  */
 export interface ILogHandler {
   readonly level: LogLevel | LogLevel[];
-  handle(record: ILogRecord | LogLevel[]): void;
+  handle(record: ILogRecord): void;
 }
 
 /**

--- a/src/handlers/console-handler.test.ts
+++ b/src/handlers/console-handler.test.ts
@@ -4,10 +4,12 @@ import { buildLogRecord } from "../test-helper/log-record-builder";
 import { ILogRecord } from "../log-record";
 
 describe("ConsoleHandler", () => {
-  it("should initialize its level to the given level", () => {
+  it("should initialize its level to the given level or level array", () => {
     const handler = new ConsoleHandler(LogLevel.ERROR);
+    const handler2 = new ConsoleHandler([LogLevel.ERROR, LogLevel.DEBUG]);
 
     expect(handler.level).toBe(LogLevel.ERROR);
+    expect(handler2.level).toEqual([LogLevel.ERROR, LogLevel.DEBUG]);
   });
 
   describe("format", () => {
@@ -46,17 +48,6 @@ describe("ConsoleHandler", () => {
   });
 
   describe("handle", () => {
-    it("should not handle a record with a lower level", () => {
-      const mock = jest.spyOn(global.console, "info").mockImplementation();
-      const handler = new ConsoleHandler(LogLevel.ERROR);
-
-      handler.handle(buildLogRecord({ level: LogLevel.INFO }));
-
-      expect(mock).not.toHaveBeenCalled();
-
-      mock.mockRestore();
-    });
-
     type Handle = "trace" | "debug" | "info" | "warn" | "error";
     const tests: [LogLevel, Handle][] = [
       [LogLevel.TRACE, "trace"],

--- a/src/handlers/console-handler.ts
+++ b/src/handlers/console-handler.ts
@@ -15,7 +15,7 @@ export class ConsoleHandler extends BaseHandler {
 
   private readonly format: (record: ILogRecord) => string;
 
-  constructor(level: LogLevel, options?: IConsoleHandlerOptions) {
+  constructor(level: LogLevel | LogLevel[], options?: IConsoleHandlerOptions) {
     super(level);
     this.format = options?.format ?? this.defaultFormat;
   }

--- a/src/handlers/test-handler.test.ts
+++ b/src/handlers/test-handler.test.ts
@@ -3,10 +3,24 @@ import { buildLogRecord } from "../test-helper/log-record-builder";
 import { LogLevel } from "../log-level";
 
 describe("TestHandler", () => {
+  it("should initialize its level to the given level or level array", () => {
+    const handler = new TestHandler(LogLevel.ERROR);
+    const handler2 = new TestHandler([LogLevel.ERROR, LogLevel.DEBUG]);
+
+    expect(handler.level).toBe(LogLevel.ERROR);
+    expect(handler2.level).toEqual([LogLevel.ERROR, LogLevel.DEBUG]);
+  });
+
   it("should have an empty record array after initialization", () => {
     const handler = new TestHandler();
 
     expect(handler.records).toEqual([]);
+  });
+
+  it("should use TRACE as an default level", () => {
+    const handler = new TestHandler();
+
+    expect(handler.level).toBe(LogLevel.TRACE);
   });
 
   it("adds a given record into a record array", () => {
@@ -16,20 +30,5 @@ describe("TestHandler", () => {
     handler.handle(record);
 
     expect(handler.records).toContain(record);
-  });
-
-  it("should use TRACE as an default level", () => {
-    const handler = new TestHandler();
-
-    expect(handler.level).toBe(LogLevel.TRACE);
-  });
-
-  it("should not add a record with a lower level", () => {
-    const handler = new TestHandler(LogLevel.WARNING);
-    const record = buildLogRecord({ level: LogLevel.INFO });
-
-    handler.handle(record);
-
-    expect(handler.records).toEqual([]);
   });
 });

--- a/src/handlers/test-handler.ts
+++ b/src/handlers/test-handler.ts
@@ -13,7 +13,7 @@ export class TestHandler extends BaseHandler {
   /**
    * @param level Defaults to `TRACE`.
    */
-  constructor(level: LogLevel = LogLevel.TRACE) {
+  constructor(level: LogLevel | LogLevel[] = LogLevel.TRACE) {
     super(level);
   }
 


### PR DESCRIPTION
Add first level support for handlers that only log for specific levels. See #4.

- [x] `ILogHandler` now supports an array of levels as its level property
- [x] `BaseHandler` implements the necessary functionality. So custom handlers don't have to do it.
- [x] `ConsoleHandler` extends its constructor to accept an array. Since it is changed from the `BaseHandler` constructor it has to be done explicitly.
- [x] `TestHandler` extends its constructor to accept an array. Since it is changed from the `BaseHandler` constructor it has to be done explicitly.