### PR TITLE
Feat: Add ability to store metadata on a logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@ Basic usage:
 ```typescript
 import { Logger, ConsoleHandler, LogLevel } from "logging-library";
 
-// Create a logger instance and attach a console handler with level INFO as well
+// Create a logger instance and attach a console handler with level INFO and above as well
 // as a custom handler with level WARN.
 const logger = new Logger()
   .addHandler(new ConsoleHandler(LogLevel.INFO))
-  .addHandler(new CustomHandler(LogLevel.WARN));
+  .addHandler(new CustomHandler([LogLevel.WARN, LogLevel.INFO]));
+// A handler can also be configured to only work for specific levels by passing in an array like above.
 
 // addHandler takes an optional second argument which determines where the handler is
 // actually added. Might be useful to only add a logger in Development. Example:
-const logger = new Logger().addHandler(
+const logger2 = new Logger().addHandler(
   new ConsoleHandler(LogLevel.INFO),
   process.env.NODE_ENV === "development"
 );
@@ -134,7 +135,7 @@ Every handler must implement the `ILogHandler` interface to be usable.
 
 ```typescript
 interface ILogHandler {
-  readonly level: LogLevel;
+  readonly level: LogLevel | LogLevel[];
   handle(record: ILogRecord): void;
 }
 ```
@@ -148,7 +149,7 @@ method which is called for all passed `LogRecords`.
 import { BaseHandler } from "logging-library";
 
 class CustomHandler extends BaseHandler {
-  constructor(level: LogLevel) {
+  constructor(level: LogLevel | LogLevel[]) {
     super(level);
   }
 
@@ -270,7 +271,7 @@ globalThis.toggleConsoleLogging = ConsoleHandler.toggle;
 class TestHandler extends BaseHandler {
   public readonly records: ILogRecord[] = [];
 
-  constructor(level: LogLevel = LogLevel.VERBOSE) {
+  constructor(level: LogLevel | LogLevel[] = LogLevel.VERBOSE) {
     super(level);
   }
 

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -20,7 +20,7 @@ describe("BaseHandler", () => {
   it("should accept an level array as a constructor argument", () => {
     const handler = new SpyHandler([LogLevel.INFO, LogLevel.CRITICAL]);
 
-    expect(handler.level).toEqual([LogLevel.INFO, LogLevel.CRITICAL]);
+    expect(handler.level).toStrictEqual([LogLevel.INFO, LogLevel.CRITICAL]);
   });
 
   describe("handle", () => {

--- a/src/handlers/console-handler.test.ts
+++ b/src/handlers/console-handler.test.ts
@@ -9,7 +9,7 @@ describe("ConsoleHandler", () => {
     const handler2 = new ConsoleHandler([LogLevel.ERROR, LogLevel.DEBUG]);
 
     expect(handler.level).toBe(LogLevel.ERROR);
-    expect(handler2.level).toEqual([LogLevel.ERROR, LogLevel.DEBUG]);
+    expect(handler2.level).toStrictEqual([LogLevel.ERROR, LogLevel.DEBUG]);
   });
 
   describe("format", () => {

--- a/src/handlers/test-handler.test.ts
+++ b/src/handlers/test-handler.test.ts
@@ -8,13 +8,13 @@ describe("TestHandler", () => {
     const handler2 = new TestHandler([LogLevel.ERROR, LogLevel.DEBUG]);
 
     expect(handler.level).toBe(LogLevel.ERROR);
-    expect(handler2.level).toEqual([LogLevel.ERROR, LogLevel.DEBUG]);
+    expect(handler2.level).toStrictEqual([LogLevel.ERROR, LogLevel.DEBUG]);
   });
 
   it("should have an empty record array after initialization", () => {
     const handler = new TestHandler();
 
-    expect(handler.records).toEqual([]);
+    expect(handler.records).toStrictEqual([]);
   });
 
   it("should use VERBOSE as an default level", () => {

--- a/src/log-record.test.ts
+++ b/src/log-record.test.ts
@@ -3,7 +3,11 @@ import { LogLevel } from "./log-level";
 
 describe("LogRecord", () => {
   it("should construct a valid LogRecord", () => {
-    const record = new LogRecord(LogLevel.INFO, "Test", "test message");
+    const record = new LogRecord("test message", {
+      level: LogLevel.INFO,
+      context: "Test",
+      metadata: { key1: 123 },
+    });
 
     expect(record.level).toBe(LogLevel.INFO);
     expect(record.levelName).toBe("INFO");
@@ -16,8 +20,12 @@ describe("LogRecord", () => {
     jest.useFakeTimers("modern");
     jest.setSystemTime(date);
 
-    const record = new LogRecord(LogLevel.INFO, "Test", "test message");
+    const record = new LogRecord("test message", {
+      level: LogLevel.INFO,
+      context: "Test",
+      metadata: { key1: 123 },
+    });
 
-    expect(record.date).toEqual(date);
+    expect(record.date).toStrictEqual(date);
   });
 });

--- a/src/log-record.ts
+++ b/src/log-record.ts
@@ -14,6 +14,14 @@ export interface ILogRecord {
   readonly message: string;
   /** Timestamp at which the log record was created. */
   readonly date: Date;
+  /** Extra meta data configured with a logger. */
+  readonly metadata: Record<string, unknown>;
+}
+
+interface LogRecordConfig {
+  level: LogLevel;
+  context: string;
+  metadata: Record<string, unknown>;
 }
 
 /**
@@ -26,12 +34,14 @@ export class LogRecord implements ILogRecord {
   readonly context: string;
   readonly message: string;
   readonly date: Date;
+  readonly metadata: Record<string, unknown>;
 
-  constructor(level: LogLevel, context: string, msg: string) {
-    this.level = level;
-    this.levelName = getLogLevelName(level);
-    this.context = context;
-    this.message = msg;
+  constructor(message: string, config: LogRecordConfig) {
+    this.level = config.level;
+    this.levelName = getLogLevelName(config.level);
+    this.context = config.context;
+    this.message = message;
     this.date = new Date();
+    this.metadata = config.metadata;
   }
 }

--- a/src/test-helper/log-record-builder.ts
+++ b/src/test-helper/log-record-builder.ts
@@ -8,6 +8,7 @@ export function buildLogRecord(overrides?: Partial<ILogRecord>): ILogRecord {
     level: LogLevel.DEBUG,
     levelName: getLogLevelName(overrides?.level ?? LogLevel.DEBUG),
     message: "Test message",
+    metadata: { test: "Test meta" },
     ...overrides,
   };
 }


### PR DESCRIPTION
close #3 

This adds the ability to store metadata on a logger. Existing metadata is merged with the new metadata while existing keys are overwritten. Metadata is attached to a `ILogRecord` using the new `ILogRecord.metadata` property.
