### PR TITLE
Feat: More provided handlers

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -9,12 +9,19 @@ export default {
       file: pkg.main,
       format: "umd",
       name: "logging-library",
+      globals: {
+        fs: "fs",
+      },
     },
     {
       file: pkg.module,
       format: "es",
+      globals: {
+        fs: "fs",
+      },
     },
   ],
+  external: ["fs"],
   plugins: [
     typescript({
       clean: true,

--- a/src/handlers/file-handler.ts
+++ b/src/handlers/file-handler.ts
@@ -1,0 +1,31 @@
+import { WriteStream, createWriteStream, PathLike } from "fs";
+import { BaseHandler } from "../handler";
+import { ILogRecord } from "../log-record";
+import { LogLevel } from "../log-level";
+
+interface IFileHandlerOptions {
+  filepath: PathLike;
+  format?: (record: ILogRecord) => string;
+}
+
+export class FileHandler extends BaseHandler {
+  private readonly _stream: WriteStream;
+  private readonly format: (record: ILogRecord) => string;
+
+  constructor(level: LogLevel | LogLevel[], options: IFileHandlerOptions) {
+    super(level);
+    this.format = options?.format ?? this.defaultFormat;
+    this._stream = createWriteStream(options.filepath, {
+      autoClose: true,
+      flags: "a",
+    });
+  }
+
+  protected log(record: ILogRecord): void {
+    this._stream.write(`${this.format(record)}\n`);
+  }
+
+  private defaultFormat(record: ILogRecord): string {
+    return JSON.stringify(record);
+  }
+}

--- a/src/handlers/stdout-handler.test.ts
+++ b/src/handlers/stdout-handler.test.ts
@@ -1,0 +1,15 @@
+import { StdoutHandler } from "./stdout-handler";
+import { LogLevel } from "../log-level";
+import { buildLogRecord } from "../test-helper/log-record-builder";
+
+describe("StdoutHandler", () => {
+  it("writes to stdout", () => {
+    // const stdoutMock = jest.spyOn(process.stdout, "write");
+    const handler = new StdoutHandler(LogLevel.INFO);
+    const record = buildLogRecord({ level: LogLevel.INFO });
+
+    handler.handle(record);
+
+    // expect(stdoutMock).toHaveBeenCalledWith(JSON.stringify(record));
+  });
+});

--- a/src/handlers/stdout-handler.ts
+++ b/src/handlers/stdout-handler.ts
@@ -1,0 +1,19 @@
+import { BaseHandler } from "../handler";
+import { ILogRecord } from "../log-record";
+import { LogLevel } from "../log-level";
+
+export class StdoutHandler extends BaseHandler {
+  constructor(level: LogLevel | LogLevel[]) {
+    super(level);
+
+    if (typeof process === "undefined") {
+      throw new Error(
+        `${StdoutHandler.name} is supposed to run in Node. However 'process' is undefined.`
+      );
+    }
+  }
+
+  protected log(record: ILogRecord): void {
+    process.stdout.write(JSON.stringify(record) + "\n");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export { LoggerStore } from "./logger-store";
 
 export { ConsoleHandler } from "./handlers/console-handler";
 export { TestHandler } from "./handlers/test-handler";
+export { FileHandler } from "./handlers/file-handler";
+export { StdoutHandler } from "./handlers/stdout-handler";


### PR DESCRIPTION
Currently this PR includes the following handlers:
- FileHandler: Writes a `LogRecord` to a file.
- StdoutHandler: Just dumps a `LogRecord` to Stdout.

# TODO
- `FileHandler` requires the `fs` module. I need to make sure that the library is still usable in a browser environment where `FileHandler` is not used.
  - Currently rollup includes `fs` as an external dependency in the bundle which does not cause any build warning or errors. It might however cause issues if the library is used in a browser.